### PR TITLE
AI star announcements via hypeman-social: posts that explain the starred project

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
           pip install pytest
 
       - name: Validate Python syntax
-        run: python -m py_compile star-daemon.py star_daemon.py github_stars.py config.py connectors/*.py tests/*.py
+        run: python -m py_compile star-daemon.py star_daemon.py star_announcer.py github_stars.py config.py connectors/*.py tests/*.py
 
       - name: Run test suite
         run: pytest -v
@@ -88,7 +88,7 @@ jobs:
       - name: Test Docker image
         run: |
           # Test that Python modules are syntactically valid without requiring env vars
-          docker run --rm star-daemon:test sh -c "python -m py_compile /app/star-daemon.py /app/star_daemon.py /app/github_stars.py /app/config.py /app/connectors/*.py"
+          docker run --rm star-daemon:test sh -c "python -m py_compile /app/star-daemon.py /app/star_daemon.py /app/star_announcer.py /app/github_stars.py /app/config.py /app/connectors/*.py"
 
   # Docker publishing is handled by docker-build-publish.yml workflow
   # which publishes to both GitHub Container Registry (ghcr.io) and Docker Hub

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -76,7 +76,7 @@ jobs:
         echo "Testing image: $IMAGE_TAG"
         # Just validate Python syntax and imports without executing config
         docker run --rm "$IMAGE_TAG" python -c "import sys; print('Python version:', sys.version); print('Import test successful')"
-        docker run --rm "$IMAGE_TAG" python -m py_compile star-daemon.py star_daemon.py github_stars.py config.py
+        docker run --rm "$IMAGE_TAG" python -m py_compile star-daemon.py star_daemon.py star_announcer.py github_stars.py config.py
         docker run --rm "$IMAGE_TAG" sh -c "cd connectors && python -m py_compile *.py"
 
     - name: Scan image with Trivy

--- a/README.md
+++ b/README.md
@@ -330,6 +330,44 @@ MESSAGE_TEMPLATE="⭐ Starred {name}: {description}\n{url}"
 MESSAGE_TEMPLATE="🌟 New star: {url}"
 ```
 
+## 🤖 AI Star Announcements (Optional)
+
+Instead of the fixed template, Star-Daemon can ask an LLM to explain what the
+starred project actually *is* — a sentence or two written from the repo's
+name, description, language, and topics. It uses the same shared LLM layer
+([hypeman-social](https://github.com/ChiefGyk3D/hypeman)) as Boon-Tube-Daemon
+and stream-daemon, so a local Ollama server is a first-class citizen:
+
+```bash
+# In .env or Doppler
+LLM_ENABLE=true
+LLM_PROVIDER=ollama
+LLM_OLLAMA_HOST=http://your-ollama-box   # default: http://localhost
+LLM_OLLAMA_PORT=11434
+LLM_OLLAMA_MODEL=gemma3:4b               # or any model Ollama can load
+
+# Optional: fail over to Gemini when the local box is down (opt-in)
+LLM_FALLBACK_PROVIDER=gemini
+GEMINI_API_KEY=your_key_here
+
+# Or use Gemini as the primary instead:
+# LLM_PROVIDER=gemini
+```
+
+Example — starring `sharkdp/bat` posts something like:
+
+> Just starred bat — a modern take on cat written in Rust, with syntax
+> highlighting and git integration baked in. My terminal thanks me.
+>
+> https://github.com/sharkdp/bat
+
+Honesty guardrails are built in: the model only sees the repo's real
+metadata, and any message containing an invented star count, version number,
+"trending", or similar fabrication is rejected. When the LLM is disabled,
+unreachable, or its message fails validation, the daemon simply posts your
+`MESSAGE_TEMPLATE` instead — a star is never left unannounced because the AI
+box is down, and the connection heals automatically when it returns.
+
 ## 🏗️ Project Structure
 
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 # Copy the application files
 COPY star-daemon.py /app/
 COPY star_daemon.py /app/
+COPY star_announcer.py /app/
 COPY github_stars.py /app/
 COPY config.py /app/
 COPY connectors/ /app/connectors/

--- a/requirements.in
+++ b/requirements.in
@@ -22,4 +22,4 @@ hvac
 # Shared LLM layer (Ollama + Gemini with guardrails and failover), from the
 # hypeman-social library used across ChiefGyk3D's daemons.
 # TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/refs/heads/claude/hypeman-library-extraction-46rmfh.tar.gz
+hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz

--- a/requirements.in
+++ b/requirements.in
@@ -22,4 +22,4 @@ hvac
 # Shared LLM layer (Ollama + Gemini with guardrails and failover), from the
 # hypeman-social library used across ChiefGyk3D's daemons.
 # TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ git+https://github.com/ChiefGyk3D/hypeman.git@claude/hypeman-library-extraction-46rmfh
+hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/refs/heads/claude/hypeman-library-extraction-46rmfh.tar.gz

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,8 @@ beautifulsoup4
 doppler-sdk
 boto3
 hvac
+
+# Shared LLM layer (Ollama + Gemini with guardrails and failover), from the
+# hypeman-social library used across ChiefGyk3D's daemons.
+# TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
+hypeman-social[ollama,gemini] @ git+https://github.com/ChiefGyk3D/hypeman.git@claude/hypeman-library-extraction-46rmfh

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ six==1.17.0
 # AI star announcements: shared LLM layer (Ollama + Gemini with guardrails
 # and failover) from the hypeman-social library.
 # TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/refs/heads/claude/hypeman-library-extraction-46rmfh.tar.gz
+hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ six==1.17.0
 # AI star announcements: shared LLM layer (Ollama + Gemini with guardrails
 # and failover) from the hypeman-social library.
 # TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ git+https://github.com/ChiefGyk3D/hypeman.git@claude/hypeman-library-extraction-46rmfh
+hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/refs/heads/claude/hypeman-library-extraction-46rmfh.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,7 @@ hvac==2.4.0  # HashiCorp Vault
 # Dependencies
 python-dateutil==2.9.0.post0
 six==1.17.0
+# AI star announcements: shared LLM layer (Ollama + Gemini with guardrails
+# and failover) from the hypeman-social library.
+# TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
+hypeman-social[ollama,gemini] @ git+https://github.com/ChiefGyk3D/hypeman.git@claude/hypeman-library-extraction-46rmfh

--- a/star_announcer.py
+++ b/star_announcer.py
@@ -1,0 +1,182 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+AI-written star announcements, powered by hypeman-social.
+
+Instead of the bare template ("I just starred X: <url>"), the daemon can ask
+an LLM to say what the project actually *is* — a sentence or two drawn from
+the repository's name, description, language, and topics. Runs against a
+local Ollama server (gemma3 by default) exactly like the other daemons, with
+Gemini available as provider or failover.
+
+Configuration (same keys as Boon-Tube-Daemon and stream-daemon):
+
+    LLM_ENABLE=true
+    LLM_PROVIDER=ollama            # or gemini
+    LLM_OLLAMA_HOST=http://your-ollama-box
+    LLM_OLLAMA_PORT=11434
+    LLM_OLLAMA_MODEL=gemma3:4b
+    LLM_FALLBACK_PROVIDER=gemini   # optional, opt-in failover
+
+The guardrails matter more here than anywhere else: a model asked to describe
+a repo it cannot see will happily invent star counts, versions, and "trending
+on GitHub". hypeman's STAR_PROFILE rejects a message containing any of those,
+and the daemon then falls back to the honest template.
+"""
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from hypeman_social.llm import STAR_PROFILE, LLMManager
+
+logger = logging.getLogger(__name__)
+
+#: Keep generated content well under Bluesky's 300-grapheme limit so the
+#: same message (plus URL) fits every connected platform.
+CONTENT_MAX_CHARS = 220
+
+
+class StarAnnouncer:
+    """
+    Generates a short explanation of a starred repository.
+
+    Wraps hypeman-social's LLMManager (reconnection, retries, failover).
+    When disabled or unavailable, compose() returns None and the daemon
+    uses its configured MESSAGE_TEMPLATE instead — a star is never left
+    unannounced because the AI box is down.
+    """
+
+    def __init__(self):
+        self.engine = LLMManager(profile=STAR_PROFILE)
+        self.enabled = False
+
+    def initialize(self) -> bool:
+        """Bring up the configured provider(s). False when LLM_ENABLE is off."""
+        if self.engine.authenticate():
+            self.enabled = True
+            logger.info(f"Star announcer ready (provider: {self.engine.provider})")
+        return self.enabled
+
+    def status(self) -> Dict[str, Any]:
+        """Provider state, for logging and diagnostics."""
+        return self.engine.status()
+
+    def compose(self, repo_data: Dict[str, Any], url: str) -> Optional[str]:
+        """
+        Write an announcement that explains what the starred project is.
+
+        Args:
+            repo_data: Repository fields (full_name, description, language,
+                topics) as provided by the GitHub API.
+            url: The repository URL, appended after validation.
+
+        Returns:
+            The finished message with URL, or None when generation failed or
+            the message didn't survive the anti-hallucination guardrails —
+            the caller falls back to its template either way.
+        """
+        if not self.enabled:
+            return None
+
+        name = repo_data.get("full_name") or repo_data.get("name") or ""
+        description = (repo_data.get("description") or "").strip()
+        language = repo_data.get("language") or ""
+        topics = repo_data.get("topics") or []
+
+        prompt = self._build_prompt(name, description, language, topics)
+
+        message = self.engine.generate(prompt)
+        if not message:
+            logger.warning("Star announcer: generation failed, using template")
+            return None
+
+        message = self._strip_meta_text(message)
+
+        cleaned, issues = self.engine.apply_guardrails(
+            message,
+            title=description or name,
+            username=name.split("/")[0] if "/" in name else name,
+            platform="generic",
+            char_limit=CONTENT_MAX_CHARS,
+            expected_hashtag_count=0,
+        )
+        if not cleaned:
+            logger.warning(
+                f"Star announcer: message failed guardrails ({'; '.join(issues)}), "
+                f"using template"
+            )
+            return None
+
+        logger.info(f"✨ Generated star announcement: {cleaned[:60]}...")
+        return f"{cleaned}\n\n{url}"
+
+    @staticmethod
+    def _build_prompt(name: str, description: str, language: str, topics) -> str:
+        """
+        Prompt tuned for small local models (gemma3:4b class).
+
+        The hard rule is honesty: the model only knows what we hand it, so
+        every instruction pushes it toward rephrasing the facts it has and
+        away from inventing the ones it doesn't.
+        """
+        facts = [f'REPOSITORY: "{name}"']
+        if description:
+            facts.append(f'DESCRIPTION: "{description}"')
+        if language:
+            facts.append(f"PRIMARY LANGUAGE: {language}")
+        if topics:
+            facts.append(f'TOPICS: {", ".join(str(t) for t in topics[:8])}')
+        facts_block = "\n".join(facts)
+
+        return f"""You are a developer sharing a GitHub project you just starred, explaining briefly what it is and why it's interesting.
+
+KNOWN FACTS (this is ALL you know about the project):
+{facts_block}
+
+TASK: Write a short post (1-2 sentences) that says you starred this project and explains what it does, in your own words.
+
+RULES (FOLLOW EXACTLY):
+✓ Length: MUST be {CONTENT_MAX_CHARS} characters or less
+✓ Output: ONLY the post text (no quotes, no meta-commentary, no "Here's...")
+✓ Rephrase the description naturally — explain it like you'd tell a colleague
+✓ Mention you starred it (e.g. "Just starred...", "Starred X today —", "Added a star to...")
+✗ DO NOT include any URL (it's added automatically)
+✗ DO NOT include hashtags
+✗ DO NOT invent anything not in the facts above: no star counts, no version
+  numbers, no "trending", no release dates, no contributor counts, no
+  features the description doesn't mention
+✗ DO NOT use hype words: "INSANE", "EPIC", "game-changer", "revolutionary", "must-see"
+
+EXAMPLES OF GOOD POSTS:
+
+Facts: "sharkdp/bat" — "A cat(1) clone with wings" — Rust
+Good: "Just starred bat — a modern take on cat written in Rust, with syntax highlighting and git integration baked in. My terminal thanks me."
+
+Facts: "excalidraw/excalidraw" — "Virtual whiteboard for sketching hand-drawn like diagrams" — TypeScript
+Good: "Starred Excalidraw today. A virtual whiteboard for sketching diagrams that look hand-drawn — great for architecture doodles that shouldn't look too official."
+
+BAD examples to AVOID:
+✗ "Just starred this AMAZING project with 50k stars!" (invented star count, hype)
+✗ "Check out v2.3.1 of this trending repo!" (invented version, invented trending)
+
+NOW: Write the post for "{name}". Under {CONTENT_MAX_CHARS} characters. No hashtags, no URLs.
+
+Post:"""
+
+    @staticmethod
+    def _strip_meta_text(message: str) -> str:
+        """Remove model chatter and any URL it invented."""
+        message = message.strip()
+        message = re.sub(
+            r"^(?:Here\'?s|Okay,? here\'?s|Sure|Certainly)[^:\n]*:\s*",
+            "",
+            message,
+            flags=re.IGNORECASE,
+        )
+        message = message.strip().strip('"').strip()
+        message = re.sub(r"https?://[^\s]+", "", message)
+        message = re.sub(r"[ \t]{2,}", " ", message)
+        return message.strip()

--- a/star_daemon.py
+++ b/star_daemon.py
@@ -25,6 +25,7 @@ from connectors import (
     MatrixConnector,
 )
 from github_stars import RateLimitError, StarWatcher
+from star_announcer import StarAnnouncer
 
 # Configure logging
 logging.basicConfig(
@@ -45,6 +46,7 @@ class StarDaemon:
         self.watcher: Optional[StarWatcher] = None
         self.starred_repos: Set[str] = set()
         self.connectors = []
+        self.announcer: Optional[StarAnnouncer] = None
         self.running = True
         self.state_file = Path(state_file or config.state_file or DEFAULT_STATE_FILE)
         self._last_resync = time.time()
@@ -90,6 +92,14 @@ class StarDaemon:
 
             # Initialize connectors
             self._initialize_connectors()
+
+            # Optional AI announcements (LLM_ENABLE + LLM_PROVIDER config).
+            # When disabled or the server is down, posts use MESSAGE_TEMPLATE.
+            self.announcer = StarAnnouncer()
+            if self.announcer.initialize():
+                logger.info("AI star announcements enabled")
+            else:
+                logger.info("AI star announcements disabled (using message template)")
 
             return True
         except RateLimitError as e:
@@ -207,23 +217,29 @@ class StarDaemon:
             owner = repo.get("owner") or {}
             description = repo.get("description")
 
-            # Build message
-            message = config.message_template.format(
-                url=repo.get("html_url"),
-                name=repo.get("full_name"),
-                description=description or "No description",
-            )
-
             # Prepare repository data for rich embeds
             repo_data = {
                 "full_name": repo.get("full_name"),
                 "name": repo.get("name"),
                 "description": description,
                 "language": repo.get("language"),
+                "topics": repo.get("topics") or [],
                 "stargazers_count": repo.get("stargazers_count"),
                 "forks_count": repo.get("forks_count"),
                 "owner": {"avatar_url": owner.get("avatar_url")},
             }
+
+            # Build message: AI explanation of what the project is when the
+            # LLM is up, the configured template otherwise.
+            message = None
+            if self.announcer is not None:
+                message = self.announcer.compose(repo_data, repo.get("html_url"))
+            if not message:
+                message = config.message_template.format(
+                    url=repo.get("html_url"),
+                    name=repo.get("full_name"),
+                    description=description or "No description",
+                )
 
             # Prepare metadata with repo_data for connectors
             metadata = {

--- a/tests/test_announcer.py
+++ b/tests/test_announcer.py
@@ -1,0 +1,182 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+The AI star announcer: prompts, guardrail handling, and the daemon's
+fallback to MESSAGE_TEMPLATE when the LLM can't deliver.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+import star_daemon
+from star_announcer import CONTENT_MAX_CHARS, StarAnnouncer
+from tests.fake_github import FakeGitHubAPI
+from tests.test_daemon import DummyConnector, make_daemon, seed
+
+REPO = {
+    "full_name": "sharkdp/bat",
+    "name": "bat",
+    "description": "A cat(1) clone with wings",
+    "language": "Rust",
+    "topics": ["cli", "rust", "terminal"],
+}
+URL = "https://github.com/sharkdp/bat"
+GOOD = "Just starred bat — a modern cat clone in Rust with syntax highlighting."
+
+
+def make_announcer(response=GOOD, guardrail_result=None):
+    announcer = StarAnnouncer.__new__(StarAnnouncer)
+    announcer.enabled = True
+    announcer.engine = Mock()
+    announcer.engine.generate.return_value = response
+    announcer.engine.apply_guardrails.return_value = (
+        guardrail_result if guardrail_result is not None else (response, [])
+    )
+    return announcer
+
+
+class TestCompose:
+    def test_message_gets_url_appended(self):
+        announcer = make_announcer()
+        result = announcer.compose(REPO, URL)
+        assert result == f"{GOOD}\n\n{URL}"
+
+    def test_prompt_contains_only_known_facts(self):
+        announcer = make_announcer()
+        announcer.compose(REPO, URL)
+        prompt = announcer.engine.generate.call_args[0][0]
+        assert "sharkdp/bat" in prompt
+        assert "A cat(1) clone with wings" in prompt
+        assert "Rust" in prompt
+        assert "cli" in prompt
+        # The character budget is stated in the prompt.
+        assert str(CONTENT_MAX_CHARS) in prompt
+
+    def test_missing_description_still_composes(self):
+        announcer = make_announcer()
+        bare = {"full_name": "x/y", "name": "y"}
+        assert announcer.compose(bare, "https://github.com/x/y") is not None
+
+    def test_generation_failure_returns_none(self):
+        announcer = make_announcer(response=None)
+        assert announcer.compose(REPO, URL) is None
+
+    def test_guardrail_failure_returns_none(self):
+        """A hallucinated star count must never be posted."""
+        announcer = make_announcer(
+            response="Starred bat! 50k stars and trending!",
+            guardrail_result=(
+                None,
+                ["Possible hallucination detected: '\\d+[km]?\\s+stars?'"],
+            ),
+        )
+        assert announcer.compose(REPO, URL) is None
+
+    def test_disabled_announcer_returns_none(self):
+        announcer = make_announcer()
+        announcer.enabled = False
+        assert announcer.compose(REPO, URL) is None
+        announcer.engine.generate.assert_not_called()
+
+    def test_meta_text_and_urls_stripped(self):
+        announcer = make_announcer(
+            response=f'Here\'s your post: "{GOOD} https://spam.example"'
+        )
+        announcer.compose(REPO, URL)
+        cleaned = announcer.engine.apply_guardrails.call_args[0][0]
+        assert cleaned.startswith("Just starred")
+        assert "spam.example" not in cleaned
+
+
+class TestDaemonIntegration:
+    def test_ai_message_used_when_available(self, tmp_path):
+        api = FakeGitHubAPI(repo_count=5)
+        daemon = make_daemon(tmp_path, api)
+        seed(daemon, api)
+        daemon.announcer = make_announcer()
+        api.star("cool/project")
+
+        daemon.check_new_stars()
+
+        message, metadata = daemon.connectors[0].posts[0]
+        assert message.startswith(GOOD)
+        assert message.endswith("https://github.com/cool/project")
+
+    def test_template_fallback_when_llm_fails(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            star_daemon.config,
+            "message_template",
+            "I just starred {name} on GitHub: {url}",
+        )
+        api = FakeGitHubAPI(repo_count=5)
+        daemon = make_daemon(tmp_path, api)
+        seed(daemon, api)
+        daemon.announcer = make_announcer(response=None)
+        api.star("cool/project")
+
+        daemon.check_new_stars()
+
+        message, _ = daemon.connectors[0].posts[0]
+        assert (
+            message
+            == "I just starred cool/project on GitHub: https://github.com/cool/project"
+        )
+
+    def test_no_announcer_uses_template(self, tmp_path, monkeypatch):
+        """Daemon constructed without an announcer (pre-LLM state) still posts."""
+        monkeypatch.setattr(
+            star_daemon.config,
+            "message_template",
+            "I just starred {name} on GitHub: {url}",
+        )
+        api = FakeGitHubAPI(repo_count=5)
+        daemon = make_daemon(tmp_path, api)
+        seed(daemon, api)
+        assert daemon.announcer is None
+        api.star("cool/project")
+
+        daemon.check_new_stars()
+        assert len(daemon.connectors[0].posts) == 1
+
+
+class TestRealGuardrails:
+    """compose() against the real hypeman guardrails (no mocked apply_guardrails)."""
+
+    def _announcer_with_real_guardrails(self, generated):
+        from hypeman_social.llm import STAR_PROFILE, LLMManager
+
+        announcer = StarAnnouncer.__new__(StarAnnouncer)
+        announcer.enabled = True
+        engine = LLMManager(profile=STAR_PROFILE)
+        engine.enabled = True
+        # Only generation is faked; guardrails run for real against a
+        # provider carrying the STAR_PROFILE.
+        engine.generate = lambda prompt, max_tokens=None: generated
+
+        from hypeman_social.llm.ollama import OllamaLLM
+
+        provider = OllamaLLM(profile=STAR_PROFILE)
+        engine.primary = provider
+        announcer.engine = engine
+        return announcer
+
+    def test_hallucinated_star_count_is_rejected(self):
+        announcer = self._announcer_with_real_guardrails(
+            "Just starred bat — trending on GitHub with 50k stars!"
+        )
+        assert announcer.compose(REPO, URL) is None
+
+    def test_honest_description_passes(self):
+        announcer = self._announcer_with_real_guardrails(GOOD)
+        result = announcer.compose(REPO, URL)
+        assert result is not None
+        assert result.endswith(URL)
+
+    def test_invented_version_is_rejected(self):
+        announcer = self._announcer_with_real_guardrails(
+            "Just starred bat v2.3.1, a cat clone in Rust."
+        )
+        assert announcer.compose(REPO, URL) is None


### PR DESCRIPTION
## What this does

New-star posts can now say what the project actually **is**, not just that you starred it. A new `star_announcer.py` asks an LLM for a one-to-two sentence description written from the repo's real metadata (name, description, language, topics), using the shared [hypeman-social](https://github.com/ChiefGyk3D/hypeman) LLM layer that Boon-Tube-Daemon and stream-daemon run on.

**Depends on** ChiefGyk3D/hypeman#1 (requirements currently install hypeman from that branch; switch to the PyPI release once it ships). Sibling PRs: ChiefGyk3D/Boon-Tube-Daemon#113, ChiefGyk3D/Stream-Daemon#220, ChiefGyk3D/yomama-as-a-service#60.

### Before / after

Before:
> I just starred sharkdp/bat on GitHub: https://github.com/sharkdp/bat

After (with `LLM_PROVIDER=ollama`, `LLM_OLLAMA_MODEL=gemma3:4b` against your Ollama box):
> Just starred bat — a modern take on cat written in Rust, with syntax highlighting and git integration baked in. My terminal thanks me.
>
> https://github.com/sharkdp/bat

### How it works

- Same config keys as the other daemons: `LLM_ENABLE`, `LLM_PROVIDER=ollama|gemini`, `LLM_OLLAMA_HOST/PORT/MODEL`, optional `LLM_FALLBACK_PROVIDER`. Local Ollama is a first-class citizen with automatic reconnection when the server comes back.
- **Honesty guardrails** (hypeman's `STAR_PROFILE`) matter more here than anywhere: a model describing a repo it can't see will happily invent star counts, versions, and "trending on GitHub". Any message containing one of those is rejected outright.
- **Template fallback everywhere**: LLM disabled, server down, or message rejected → the daemon posts your `MESSAGE_TEMPLATE` exactly as before. A star is never left unannounced because the AI box is offline.
- Repo `topics` now flow into the embed metadata for richer prompts.

Connectors are intentionally untouched — their repo-specific embeds (stars, forks, language, avatar) are purpose-built and work well; consolidating them into hypeman's platform classes is a follow-up once the library ships star-event embeds.

### Testing

- **52 passed** (baseline 39; 13 new in `tests/test_announcer.py`), including three tests that run the **real** anti-hallucination guardrails: invented star counts and version numbers are rejected, honest descriptions pass.
- Daemon integration covered: AI message used when available, template fallback on LLM failure, no-announcer (pre-LLM) path still posts.
- Local runs of everything CI enforces: black, isort, flake8 (E9,F63,F7,F82), full pytest.
- CI syntax-validation lists and the Dockerfile include the new module.
- README documents the feature and configuration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK)_