### PR TITLE
Adopt hypeman-social 0.1.0 from PyPI; link the configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ unreachable, or its message fails validation, the daemon simply posts your
 `MESSAGE_TEMPLATE` instead — a star is never left unannounced because the AI
 box is down, and the connection heals automatically when it returns.
 
+Every LLM key (guardrail tuning, retries, thinking mode for reasoning models,
+and more) is documented in the
+[hypeman-social configuration reference](https://github.com/ChiefGyk3D/hypeman/blob/main/docs/CONFIGURATION.md).
+
 ## 🏗️ Project Structure
 
 ```

--- a/requirements.in
+++ b/requirements.in
@@ -21,5 +21,4 @@ hvac
 
 # Shared LLM layer (Ollama + Gemini with guardrails and failover), from the
 # hypeman-social library used across ChiefGyk3D's daemons.
-# TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz
+hypeman-social[ollama,gemini]>=0.1.0,<0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,4 @@ python-dateutil==2.9.0.post0
 six==1.17.0
 # AI star announcements: shared LLM layer (Ollama + Gemini with guardrails
 # and failover) from the hypeman-social library.
-# TODO: switch to `hypeman-social[ollama,gemini]>=0.1.0` once it's on PyPI.
-hypeman-social[ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/126c28b5da4901e8ca102955193b71652ec9d348.tar.gz
+hypeman-social[ollama,gemini]>=0.1.0,<0.2


### PR DESCRIPTION
`hypeman-social` is now [published on PyPI](https://pypi.org/project/hypeman-social/), so the commit-tarball pin becomes `hypeman-social[ollama,gemini]>=0.1.0,<0.2` in both `requirements.txt` and `requirements.in` (0.x minors may break — hence the upper bound).

The AI Star Announcements README section now links the library's [full configuration reference](https://github.com/ChiefGyk3D/hypeman/blob/main/docs/CONFIGURATION.md) for guardrail tuning, retries, and thinking-mode keys.

Tests: 52 passed locally; the PyPI spec verified resolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK)_