### PR TITLE
deps: adopt hypeman-social 0.2.0 from PyPI

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,4 @@ hvac
 
 # Shared LLM layer (Ollama + Gemini with guardrails and failover), from the
 # hypeman-social library used across ChiefGyk3D's daemons.
-# TEMPORARY: pinned to the hypeman 0.2.0 merge commit until v0.2.0 is on
-# PyPI (the maintainer publishes the GitHub release; Trusted Publishing does
-# the rest). Swap back to: hypeman-social[bluesky,mastodon,ollama,gemini]>=0.2.0,<0.3
-hypeman-social[bluesky,mastodon,ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/60345d51254275ffcfb905d9d460d9324735f255.tar.gz
+hypeman-social[bluesky,mastodon,ollama,gemini]>=0.2.0,<0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,4 @@ python-dateutil==2.9.0.post0
 six==1.17.0
 # AI star announcements: shared LLM layer (Ollama + Gemini with guardrails
 # and failover) from the hypeman-social library.
-# TEMPORARY: pinned to the hypeman 0.2.0 merge commit until v0.2.0 is on
-# PyPI (the maintainer publishes the GitHub release; Trusted Publishing does
-# the rest). Swap back to: hypeman-social[bluesky,mastodon,ollama,gemini]>=0.2.0,<0.3
-hypeman-social[bluesky,mastodon,ollama,gemini] @ https://github.com/ChiefGyk3D/hypeman/archive/60345d51254275ffcfb905d9d460d9324735f255.tar.gz
+hypeman-social[bluesky,mastodon,ollama,gemini]>=0.2.0,<0.3


### PR DESCRIPTION
## What this does

[hypeman-social v0.2.0](https://github.com/ChiefGyk3D/hypeman/releases/tag/v0.2.0) is published on PyPI, so the temporary merge-commit tarball pin from [#99](https://github.com/ChiefGyk3D/Star-Daemon/pull/99) becomes a proper version range in `requirements.txt` and `requirements.in`:

```
hypeman-social[bluesky,mastodon,ollama,gemini]>=0.2.0,<0.3
```

Same extras as before. `<0.3` because 0.x minors may break, per the library's versioning policy. No code changes — the star-embed rendering, Threads support, and health endpoint this daemon relies on are all in 0.2.0.

## Validation

- `hypeman-social==0.2.0` verified downloadable from PyPI (wheel resolves).
- CI installs from PyPI and runs the full suite including the end-to-end integration test, which is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh6asJV76z7de9zejpmQwK)_