### PR TITLE
deps: consolidate dependency updates, fix requests CVE-2026-25645

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 # Star-Daemon Requirements
-# Updated: 2025-10-27
+# Updated: 2026-09-12
 # 
 # For Shai-Hulud mitigations with hashes, run:
 # pip-compile --generate-hashes requirements.in -o requirements-lock.txt
 # pip install -r requirements-lock.txt --require-hashes
 
 # Core dependencies
-python-dotenv==1.2.1
-requests==2.32.5
+python-dotenv==1.2.3
+requests==2.34.2
 
 # Mastodon
-Mastodon.py==2.1.4
+Mastodon.py==2.2.2
 
 # BlueSky / AT Protocol
-atproto==0.0.65
-beautifulsoup4==4.14.3
+atproto==0.0.72
+beautifulsoup4==4.15.0
 
 # Discord: posts via plain webhooks using `requests` - no SDK needed
 
@@ -22,14 +22,14 @@ beautifulsoup4==4.14.3
 # matrix-nio removed - using Matrix Client-Server API directly via requests
 
 # Security and utilities
-certifi==2026.1.4
-urllib3==2.6.3
-charset-normalizer==3.4.4
-idna==3.11
+certifi==2026.7.22
+urllib3==2.7.0
+charset-normalizer==3.5.1
+idna==3.19
 
 # Secrets Management (Optional - install what you need)
 doppler-sdk==1.3.0  # Doppler
-boto3==1.42.39  # AWS Secrets Manager
+boto3==1.43.93  # AWS Secrets Manager
 hvac==2.4.0  # HashiCorp Vault
 
 # Dependencies


### PR DESCRIPTION
Consolidates the open Dependabot backlog for this repo (16 open PRs, oldest from March) into one reviewable change, per #31. Every bump was installed and tested together rather than one at a time.

## Security

| Package | From | To | Why |
|---|---|---|---|
| `requests` | 2.32.5 | 2.34.2 | **CVE-2026-25645**, fixed in 2.33.0. `requests.utils.extract_zipped_paths` extracted to a deterministic location, allowing contents to be replaced. Star-Daemon never calls that helper, so exposure here is indirect — but the pin sat behind the fixed release. |
| `certifi` | 2026.1.4 | 2026.7.22 | Refreshes the trusted CA bundle; the old pin was ~7 months stale. |

## Runtime and transport

| Package | From | To |
|---|---|---|
| `urllib3` | 2.6.3 | 2.7.0 |
| `charset-normalizer` | 3.4.4 | 3.5.1 |
| `idna` | 3.11 | 3.19 |
| `python-dotenv` | 1.2.1 | 1.2.3 |

`urllib3` 2.7.0 matches the pin Stream-Daemon already carries, so the two daemons stop diverging.

## Platform clients and SDKs

| Package | From | To |
|---|---|---|
| `Mastodon.py` | 2.1.4 | 2.2.2 |
| `atproto` | 0.0.65 | 0.0.72 |
| `beautifulsoup4` | 4.14.3 | 4.15.0 |
| `boto3` | 1.42.39 | 1.43.93 |

`hypeman-social` 0.2.0 constrains all of these with lower bounds only (`requests>=2.31.0`, `atproto>=0.0.55`, `beautifulsoup4>=4.12.0`, `Mastodon.py>=1.8.1`, `boto3>=1.34.0`), so none of these bumps crosses one of its caps.

## Test status

Run locally on Python 3.11, which is in the CI matrix:

- `pip install -r requirements.txt` — resolves clean
- `pip check` — no broken requirements
- `python -m py_compile` over the same file list the CI test job uses — clean
- `pytest` — **61 passed**, same count as the pre-change baseline, no new failures or skips
- `black --check .` — 15 files unchanged
- `isort --check-only .` — clean
- `flake8 --select=E9,F63,F7,F82` — 0
- Import smoke across every bumped library plus each project module — clean

## Deliberately left out

- **Docker base image `python:3.13-slim` → `3.14-slim`** (Dependabot #86). CI tests only through 3.13, so bumping the runtime image would ship an interpreter that no test job covers. The matrix should be extended to 3.14 first, in its own PR.
- **The five GitHub Actions bumps** (#87, #91–#94). Two are majors on the image publish path (`setup-buildx` 3→4, `build-push-action` 6→7) and deserve a separate PR with freshly resolved SHA pins rather than riding along here.

## Dependabot PRs this supersedes

Closeable once this merges: #59 (certifi), #77 and #88 (requests), #81 (charset-normalizer), #89 (boto3), #90 (python-dotenv).

Separately, four open Dependabot PRs target dependencies **this repo no longer has** — #70 (`discord-py`), #74 (`protobuf`), #76 (`pygithub`), #83 (`aiohttp`). None of those appear in `requirements.txt` or `requirements.in` anymore; Discord now posts via plain webhooks using `requests`. They are stale and can be closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTP76PfcwdqCSwN6Jg6sH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTP76PfcwdqCSwN6Jg6sH)_